### PR TITLE
fix: ensure attribute is string

### DIFF
--- a/lib/attr.js
+++ b/lib/attr.js
@@ -7,7 +7,7 @@ export function parseAttr(attrStr, rule) {
     return attrStr;
   }
 
-  const attrValues = delimiter ? attrStr.split(delimiter) : [attrStr];
+  const attrValues = delimiter ? String(attrStr).split(delimiter) : [attrStr];
   if (!keyDelimiter) {
     return attrValues;
   }


### PR DESCRIPTION
This fixes a regression introduced in 8601df6

In order to not automatically add `=""` to no-value attributes, the attribute's value is set to `true` if it's empty/undefined.

This can result in a `TypeError: attrStr.split is not a function` because we're using `.spli()` on a `Boolean`.

This PR ensures the value is correct by casting it to a `String`.