### PR TITLE
Fix base64 strings

### DIFF
--- a/lib/parseRules.js
+++ b/lib/parseRules.js
@@ -4,7 +4,7 @@ export default {
     glue: ' '
   },
   style: {
-    delimiter: /\s*;\s*/,
+    delimiter: /\s*;\s*(?![^()]*\))/,
     keyDelimiter: /\s*:\s*/,
     glue: '; ',
     keyGlue: ': '

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -22,11 +22,20 @@ test('should parse "style" attr', () => {
   const tree = getTree('<i style="color: red !important; background: url(http://github.com/logo.png); color: blue;"></i>');
   const attrs = parseAttrs(tree[0].attrs);
 
+  const base64String = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=';
+  const base64Tree = getTree(`<i style="background: url(${base64String});"></i>`);
+  const base64Attrs = parseAttrs(base64Tree[0].attrs);
+
   assertAttrs(attrs, {style: {
     'color': ['red !important', 'blue'],
     'background': 'url(http://github.com/logo.png)'
   }});
   expect(attrs.compose()).toEqual({style: 'color: red !important; color: blue; background: url(http://github.com/logo.png)'});
+
+  assertAttrs(base64Attrs, {style: {
+    'background': `url(${base64String})`
+  }});
+  expect(base64Attrs.compose()).toEqual({style: `background: url(${base64String})`});
 });
 
 test('should parse custom list attrs', () => {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -23,7 +23,7 @@ test('should parse "style" attr', () => {
   const attrs = parseAttrs(tree[0].attrs);
 
   const base64String = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=';
-  const base64Tree = getTree(`<i style="background: url('${base64String}');"></i>`);
+  const base64Tree = getTree(`<i style="color: red !important; background: url('${base64String}'); color: blue;"></i>`);
   const base64Attrs = parseAttrs(base64Tree[0].attrs);
 
   assertAttrs(attrs, {style: {
@@ -33,9 +33,10 @@ test('should parse "style" attr', () => {
   expect(attrs.compose()).toEqual({style: 'color: red !important; color: blue; background: url(http://github.com/logo.png)'});
 
   assertAttrs(base64Attrs, {style: {
+    'color': ['red !important', 'blue'],
     'background': `url('${base64String}')`
   }});
-  expect(base64Attrs.compose()).toEqual({style: `background: url('${base64String}')`});
+  expect(base64Attrs.compose()).toEqual({style: `color: red !important; color: blue; background: url('${base64String}')`});
 });
 
 test('should parse custom list attrs', () => {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -23,7 +23,7 @@ test('should parse "style" attr', () => {
   const attrs = parseAttrs(tree[0].attrs);
 
   const base64String = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=';
-  const base64Tree = getTree(`<i style="background: url(${base64String});"></i>`);
+  const base64Tree = getTree(`<i style="background: url('${base64String}');"></i>`);
   const base64Attrs = parseAttrs(base64Tree[0].attrs);
 
   assertAttrs(attrs, {style: {
@@ -33,9 +33,9 @@ test('should parse "style" attr', () => {
   expect(attrs.compose()).toEqual({style: 'color: red !important; color: blue; background: url(http://github.com/logo.png)'});
 
   assertAttrs(base64Attrs, {style: {
-    'background': `url(${base64String})`
+    'background': `url('${base64String}')`
   }});
-  expect(base64Attrs.compose()).toEqual({style: `background: url(${base64String})`});
+  expect(base64Attrs.compose()).toEqual({style: `background: url('${base64String}')`});
 });
 
 test('should parse custom list attrs', () => {


### PR DESCRIPTION
Currently, the plugin returns an incomplete CSS value for strings containing a `;` character, like those used in base64 data.

\- Expected
\+ Received

``` diff
  Object {
    "style": Object {
-     "background": "url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=)",
+     "background": "url(data:image/png",
    },
  }
```